### PR TITLE
Fixed hexo-deployer-ftpsync/issue/21

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,5 +39,8 @@ hexo.extend.deployer.register('ftpsync', function(args, callback){
     ftpsync.settings.port = 21;
   }
 
-  ftpsync.run(callback);
+  ftpsync.run(()=>{
+    callback();
+    process.exit();
+  });
 });

--- a/index.js
+++ b/index.js
@@ -39,8 +39,8 @@ hexo.extend.deployer.register('ftpsync', function(args, callback){
     ftpsync.settings.port = 21;
   }
 
-  ftpsync.run(()=>{
-    callback();
+  ftpsync.run((args)=>{
+    callback(args);
     process.exit();
   });
 });


### PR DESCRIPTION
 - Ftp Sync does not exit
forced call to "process.exit()" to terminate deploy command